### PR TITLE
feat: remember “Show completed tasks” across app restarts & haptic feedbacks when marking tasks done.

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,17 +39,21 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
+        if (keystorePropertiesFile.exists()) {
+            create("release") {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
         }
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = false
             isShrinkResources = false
             proguardFiles(

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,21 +39,17 @@ android {
     }
 
     signingConfigs {
-        if (keystorePropertiesFile.exists()) {
-            create("release") {
-                storeFile = file(keystoreProperties["storeFile"] as String)
-                storePassword = keystoreProperties["storePassword"] as String
-                keyAlias = keystoreProperties["keyAlias"] as String
-                keyPassword = keystoreProperties["keyPassword"] as String
-            }
+        create("release") {
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
         }
     }
 
     buildTypes {
         release {
-            if (keystorePropertiesFile.exists()) {
-                signingConfig = signingConfigs.getByName("release")
-            }
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             isShrinkResources = false
             proguardFiles(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:timezone/data/latest.dart' as tz;
 import 'models/quadrant_enum.dart';
 import 'models/task_models.dart';
 import 'providers/theme_provider.dart';
+import 'providers/task_providers.dart';
 import 'screens/home_screen.dart';
 
 // Define the custom background color
@@ -41,6 +42,11 @@ void main() async {
           StateNotifierProvider<ThemeNotifier, AppTheme>((ref) {
             return ThemeNotifier(hiveService)
               ..setTheme(savedTheme ?? AppTheme.light);
+          }),
+        ),
+        showCompletedTasksNotifierProvider.overrideWithProvider(
+          StateNotifierProvider<ShowCompletedTasksNotifier, bool>((ref) {
+            return ShowCompletedTasksNotifier(hiveService);
           }),
         ),
       ],

--- a/lib/providers/task_providers.dart
+++ b/lib/providers/task_providers.dart
@@ -1,6 +1,37 @@
 // lib/providers/task_providers.dart
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/hive_service.dart';
+import '../main.dart';
 
 // Controls whether completed tasks are shown
 final showCompletedTasksProvider = StateProvider<bool>((ref) => false);
+
+// Provider that automatically saves the show completed preference when it changes
+final showCompletedTasksNotifierProvider = StateNotifierProvider<ShowCompletedTasksNotifier, bool>((ref) {
+  final hiveService = ref.watch(hiveServiceProvider);
+  return ShowCompletedTasksNotifier(hiveService);
+});
+
+class ShowCompletedTasksNotifier extends StateNotifier<bool> {
+  final HiveService _hiveService;
+
+  ShowCompletedTasksNotifier(this._hiveService) : super(false) {
+    _loadPreference();
+  }
+
+  Future<void> _loadPreference() async {
+    final preference = await _hiveService.getShowCompletedPreference();
+    state = preference;
+  }
+
+  Future<void> toggle() async {
+    state = !state;
+    await _hiveService.setShowCompletedPreference(state);
+  }
+
+  Future<void> setValue(bool value) async {
+    state = value;
+    await _hiveService.setShowCompletedPreference(state);
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -56,7 +56,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final tasks = ref.watch(taskProvider);
     final filter = ref.watch(filterProvider);
     final viewMode = ref.watch(viewModeProvider);
-    final showCompleted = ref.watch(showCompletedTasksProvider);
+    final showCompleted = ref.watch(showCompletedTasksNotifierProvider);
 
     final completedTasks = tasks.where((task) => task.isCompleted).toList();
     final incompleteTasks = tasks.where((task) => !task.isCompleted).toList();

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -44,9 +44,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
 
   // load provider
   Future<void> _loadPreferences() async {
-    final hiveService = ref.read(hiveServiceProvider);
-    final showCompleted = await hiveService.getShowCompletedPreference();
-    ref.read(showCompletedTasksProvider.notifier).state = showCompleted;
+    // The preference is now automatically loaded by the notifier provider
+    // No need to manually load it here
   }
 
   @override
@@ -54,7 +53,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final appTheme = ref.watch(themeProvider);
-    final showCompleted = ref.watch(showCompletedTasksProvider);
+    final showCompleted = ref.watch(showCompletedTasksNotifierProvider);
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
@@ -125,8 +124,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
                       ),
                       value: showCompleted,
                       onChanged: (value) {
-                        ref.read(showCompletedTasksProvider.notifier).state =
-                            value;
+                        ref.read(showCompletedTasksNotifierProvider.notifier).setValue(value);
                         HapticFeedback.selectionClick();
                       },
                       activeColor: colorScheme.primary,
@@ -488,7 +486,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
   Future<void> _clearAllData(WidgetRef ref) async {
     final hiveService = ref.read(hiveServiceProvider);
     await hiveService.clearAllData();
-    ref.invalidate(showCompletedTasksProvider);
+    ref.invalidate(showCompletedTasksNotifierProvider);
   }
 
   void _showAboutAppDialog(BuildContext context) {

--- a/lib/widgets/settings_bottomsheet.dart
+++ b/lib/widgets/settings_bottomsheet.dart
@@ -277,7 +277,7 @@ class _SettingsBottomSheetState extends ConsumerState<SettingsBottomSheet>
   @override
   Widget build(BuildContext context) {
     final appTheme = ref.watch(themeProvider);
-    final showCompleted = ref.watch(showCompletedTasksProvider);
+    final showCompleted = ref.watch(showCompletedTasksNotifierProvider);
     final colorScheme = _getColorScheme(appTheme);
 
     return SlideTransition(
@@ -582,7 +582,7 @@ class _SettingsBottomSheetState extends ConsumerState<SettingsBottomSheet>
               child: Switch.adaptive(
                 value: showCompleted,
                 onChanged: (value) {
-                  ref.read(showCompletedTasksProvider.notifier).state = value;
+                  ref.read(showCompletedTasksNotifierProvider.notifier).setValue(value);
                   HapticFeedback.lightImpact();
                 },
                 activeColor: Theme.of(context).colorScheme.primary,

--- a/lib/widgets/task_tile.dart
+++ b/lib/widgets/task_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'dart:async';
@@ -97,6 +98,7 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                 // Custom Checkbox
                 GestureDetector(
                   onTap: () {
+                    HapticFeedback.selectionClick();
                     ref
                         .read(taskProvider.notifier)
                         .toggleTaskCompletion(widget.task.id);


### PR DESCRIPTION
- Add ShowCompletedTasksNotifier to automatically save/load preference
- Update app initialization to load preference on startup
- Replace simple StateProvider with StateNotifierProvider for persistence
- Update all UI components to use new notifier provider
- Haptic feedback when marking the task done.

This change ensures the 'Show completed tasks' setting is remembered across app restarts, improving user experience by maintaining preferences between sessions.

Closes: User request for persistent setting memory #4 and haptic feedback when marking task as "Done"  #11 